### PR TITLE
Handle exception raised by 'getactions' API call

### DIFF
--- a/CRM/Csvimport/Import/Form/DataSource.php
+++ b/CRM/Csvimport/Import/Form/DataSource.php
@@ -59,10 +59,14 @@ class CRM_Csvimport_Import_Form_DataSource extends CRM_Csvimport_Import_Form_Dat
     $allEntities = civicrm_api3('entity', 'get', array());
     $creatableEntities = array();
     foreach ($allEntities['values'] as $entity) {
-      $actions = civicrm_api3($entity, 'getactions', array('entity' => $entity));
-      //can add 'submit' later when we can figure out how to specify on submit
-      if(array_intersect(array('create',), $actions['values'])) {
-        $creatableEntities[$entity] = $entity;
+      try {
+        $actions = civicrm_api3($entity, 'getactions', array('entity' => $entity));
+        //can add 'submit' later when we can figure out how to specify on submit
+        if(array_intersect(array('create',), $actions['values'])) {
+          $creatableEntities[$entity] = $entity;
+        }
+      } catch (CiviCRM_API3_Exception $e) {
+        ;
       }
     }
     $this->add('select', 'entity', ts('Entity To Import'), array('' => ts('- select -')) + $creatableEntities);

--- a/CRM/Csvimport/Import/Form/DataSource.php
+++ b/CRM/Csvimport/Import/Form/DataSource.php
@@ -65,8 +65,9 @@ class CRM_Csvimport_Import_Form_DataSource extends CRM_Csvimport_Import_Form_Dat
         if(array_intersect(array('create',), $actions['values'])) {
           $creatableEntities[$entity] = $entity;
         }
-      } catch (CiviCRM_API3_Exception $e) {
-        ;
+      }
+      catch (CiviCRM_API3_Exception $e) {
+        // Ignore entities that raise an exception
       }
     }
     $this->add('select', 'entity', ts('Entity To Import'), array('' => ts('- select -')) + $creatableEntities);


### PR DESCRIPTION
The nz.co.fuzion.accountsync extension defines entities 'AccountContact' and 'AccountInvoice' whose API calls require 'plugin' as a parameter.

This fix allows this extension to continue even though the 'getactions' call fails for those entity types.