### PR TITLE
Case import to update case data fails saying "Missing required field(…

### DIFF
--- a/CRM/Csvimport/Import/Parser/Api.php
+++ b/CRM/Csvimport/Import/Parser/Api.php
@@ -48,7 +48,7 @@ class CRM_Csvimport_Import_Parser_Api extends CRM_Csvimport_Import_Parser_BaseCl
    $this->_params = &$this->getActiveFieldParams();
 
    foreach ($this->_requiredFields as $requiredField) {
-     if(empty($this->_params[$requiredField])) {
+     if(empty($this->_params['id']) && empty($this->_params[$requiredField])) {
        $errorRequired = TRUE;
        $missingField .= ' ' . $requiredField;
        CRM_Contact_Import_Parser_Contact::addToErrorMsg($this->_entity, $requiredField);


### PR DESCRIPTION
…s) : contact_id"

Even if case id is present in the csv file, the import fails with this message. I think, if we have an `id` present we can avoid other field required validation considering it as an `update` action?