### PR TITLE
skip GroupContact.group_id validation

### DIFF
--- a/CRM/Csvimport/Task/Import.php
+++ b/CRM/Csvimport/Task/Import.php
@@ -175,6 +175,10 @@ class CRM_Csvimport_Task_Import {
       if ($entity == 'Relationship' && $fieldName == 'relationship_type_id') {
         continue;
       }
+      // exception with group_id which is numeric, and doesn't pass the validation
+      if ($entity == 'GroupContact' && $fieldName == 'group_id') {
+        continue;
+      }
       if(in_array($fieldName, $opFields)) {
         $valInfo[$fieldName] = self::validateField($entity, $fieldName, $value);
       }


### PR DESCRIPTION
similar to #16, importing  **GroupContact** with `group_id` this field is treated as *selectable* and numeric ID doesn't go through validation

this is a quick workaround, but I guess more exceptions are coming, so probably another solution more generic needs to be implemented in the future
