### PR TITLE
CGP-1018: CiviCRM Importer Update

### DIFF
--- a/CRM/Csvimport/Import/Form/DataSource.php
+++ b/CRM/Csvimport/Import/Form/DataSource.php
@@ -43,11 +43,11 @@ class CRM_Csvimport_Import_Form_DataSource extends CRM_Csvimport_Import_Form_Dat
   protected $_mappingType = 'Import Participant';//@todo make this vary depending on api - need to create option values
   protected $_entity;
   /**
-  * Include duplicate options
-  */
+   * Include duplicate options
+   */
   protected $isDuplicateOptions = FALSE;
 
-    /**
+  /**
    * Function to actually build the form - this appears to be entirely code that should be in a shared base class in core
    *
    * @return None
@@ -71,6 +71,16 @@ class CRM_Csvimport_Import_Form_DataSource extends CRM_Csvimport_Import_Form_Dat
       }
     }
     $this->add('select', 'entity', ts('Entity To Import'), array('' => ts('- select -')) + $creatableEntities);
+
+    // handle 'Note' entity
+    $entities = CRM_Core_BAO_Note::entityTables();
+    $noteEntities = array();
+    foreach ($entities as $key => $entity) {
+      $noteEntities[$entity] = $entity;
+    }
+    asort($noteEntities);
+    $this->add('select', 'noteEntity', ts('Which entity are you importing "Notes" to'), $noteEntities + array('0' => ts('Set this in CSV')));
+
     parent::buildQuickForm();
   }
 

--- a/CRM/Csvimport/Import/Form/DataSourceBaseClass.php
+++ b/CRM/Csvimport/Import/Form/DataSourceBaseClass.php
@@ -144,6 +144,7 @@ class CRM_Csvimport_Import_Form_DataSourceBaseClass extends CRM_Core_Form {
     $this->addElement('text', 'fieldSeparator', ts('Import Field Separator'), array('size' => 2));
     $this->addElement('text', 'queueBatchSize', ts('Number Of Items To Process For Each Queue Item'), array('size' => 3));
     $this->addElement('checkbox', 'allowEntityUpdate', ts('Allow Updating An Entity Using Unique Fields'));
+    $this->addElement('checkbox', 'ignoreCase', ts('Ignore Case For Field Option Values'));
     //build date formats
     CRM_Core_Form_Date::buildAllowedDateFormats($this);
 
@@ -180,6 +181,7 @@ class CRM_Csvimport_Import_Form_DataSourceBaseClass extends CRM_Core_Form {
     $entity     = $this->controller->exportValue($this->_name, 'entity');
     $queueBatchSize   = $this->controller->exportValue($this->_name, 'queueBatchSize');
     $allowEntityUpdate = $this->controller->exportValue($this->_name, 'allowEntityUpdate');
+    $ignoreCase = $this->controller->exportValue($this->_name, 'ignoreCase');
 
     $this->set('onDuplicate', $onDuplicate);
     $this->set('contactType', $contactType);
@@ -189,6 +191,7 @@ class CRM_Csvimport_Import_Form_DataSourceBaseClass extends CRM_Core_Form {
 
     $this->controller->set('queueBatchSize', $queueBatchSize);
     $this->controller->set('allowEntityUpdate', $allowEntityUpdate);
+    $this->controller->set('ignoreCase', $ignoreCase);
 
     $session = CRM_Core_Session::singleton();
     $session->set("dateTypes", $dateFormats);

--- a/CRM/Csvimport/Import/Form/DataSourceBaseClass.php
+++ b/CRM/Csvimport/Import/Form/DataSourceBaseClass.php
@@ -182,6 +182,11 @@ class CRM_Csvimport_Import_Form_DataSourceBaseClass extends CRM_Core_Form {
     $queueBatchSize   = $this->controller->exportValue($this->_name, 'queueBatchSize');
     $allowEntityUpdate = $this->controller->exportValue($this->_name, 'allowEntityUpdate');
     $ignoreCase = $this->controller->exportValue($this->_name, 'ignoreCase');
+    $noteEntity = NULL;
+    if ($entity == 'Note') {
+      $noteEntity = $this->controller->exportValue($this->_name, 'noteEntity');
+      $this->set('noteEntity', $noteEntity);
+    }
 
     $this->set('onDuplicate', $onDuplicate);
     $this->set('contactType', $contactType);

--- a/CRM/Csvimport/Import/Form/MapFieldBaseClass.php
+++ b/CRM/Csvimport/Import/Form/MapFieldBaseClass.php
@@ -93,7 +93,12 @@ class CRM_Csvimport_Import_Form_MapFieldBaseClass extends CRM_Import_Form_MapFie
     $this->doDuplicateOptionHandling();
 
     // find all reference fields for this entity
-    $refFields = $this->controller->findAllReferenceFields($this->get('entity'));
+    $params = array();
+    if ($noteEntity = $this->get('noteEntity')) {
+      $params[$this->get('entity')] = $noteEntity;
+      unset($this->_mapperFields['entity_table']);
+    }
+    $refFields = $this->controller->findAllReferenceFields($this->get('entity'), $params);
 
     // get all unique fields for above entities
     $uniqueFields = array();

--- a/CRM/Csvimport/Import/Form/PreviewBaseClass.php
+++ b/CRM/Csvimport/Import/Form/PreviewBaseClass.php
@@ -145,6 +145,7 @@ class CRM_Csvimport_Import_Form_Previewbaseclass extends CRM_Import_Form_Preview
     $parser->setImportQueueBatchSize($this->controller->get('queueBatchSize'));
 
     $parser->setAllowEntityUpdate($this->controller->get('allowEntityUpdate'));
+    $parser->setIgnoreCase($this->controller->get('ignoreCase'));
 
     foreach ($mapper as $key => $value) {
       $header = array();

--- a/CRM/Csvimport/Import/Parser/Api.php
+++ b/CRM/Csvimport/Import/Parser/Api.php
@@ -12,6 +12,7 @@ class CRM_Csvimport_Import_Parser_Api extends CRM_Csvimport_Import_Parser_BaseCl
   protected $_refFields = array();
   protected $_importQueueBatch = array();
   protected $_allowEntityUpdate = FALSE;
+  protected $_ignoreCase = FALSE;
 
   function setFields() {
    $fields = civicrm_api3($this->_entity, 'getfields', array('action' => 'create'));
@@ -163,6 +164,7 @@ class CRM_Csvimport_Import_Parser_Api extends CRM_Csvimport_Import_Parser_BaseCl
   function addToBatch($item, $values) {
     $item['rowValues'] = $values;
     $item['allowUpdate'] = $this->_allowEntityUpdate;
+    $item['ignoreCase'] = $this->_ignoreCase;
     $this->_importQueueBatch[] = $item;
   }
 
@@ -193,6 +195,14 @@ class CRM_Csvimport_Import_Parser_Api extends CRM_Csvimport_Import_Parser_BaseCl
    */
   function setAllowEntityUpdate($update) {
     $this->_allowEntityUpdate = $update;
+  }
+
+  /**
+   * Set if letter-case needs to be ignored for field option values
+   * @param $size
+   */
+  function setIgnoreCase($ignoreCase) {
+    $this->_ignoreCase = $ignoreCase;
   }
 
 }

--- a/CRM/Csvimport/Task/Import.php
+++ b/CRM/Csvimport/Task/Import.php
@@ -219,14 +219,6 @@ class CRM_Csvimport_Task_Import {
 
     $valInfo = array();
     foreach ($params as $fieldName => $value) {
-      // exception with relation_type_id which is numeric, and doesn't pass the validation
-      if ($entity == 'Relationship' && $fieldName == 'relationship_type_id') {
-        continue;
-      }
-      // exception with group_id which is numeric, and doesn't pass the validation
-      if ($entity == 'GroupContact' && $fieldName == 'group_id') {
-        continue;
-      }
       if(in_array($fieldName, $opFields)) {
         $valInfo[$fieldName] = self::validateField($entity, $fieldName, $value, $ignoreCase);
       }
@@ -246,12 +238,6 @@ class CRM_Csvimport_Task_Import {
    * @return array
    */
   private static function validateField($entity, $field, $value, $ignoreCase = FALSE) {
-    // Horrible hack to get around
-    // https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport/issues/21
-    if ($entity == 'Relationship' && $field == 'relationship_type_id') {
-      return array('error' => 0);
-    }
-
     $options = self::getFieldOptionsMeta($entity, $field);
 
     $optionKeys = array_keys($options);

--- a/CRM/Csvimport/Task/Import.php
+++ b/CRM/Csvimport/Task/Import.php
@@ -220,6 +220,7 @@ class CRM_Csvimport_Task_Import {
       $value = strtolower($value);
     }
     $value = explode('|', $value);
+    $value = array_filter($value); // filter empty values
     $valueUpdated = FALSE;
     $isValid = TRUE;
 
@@ -228,7 +229,7 @@ class CRM_Csvimport_Task_Import {
         $isValid = FALSE;
         // check 'label' if 'name' not found
         foreach ($options as $name => $label) {
-          if($mval == $label) {
+          if($mval == $label || ($ignoreCase && strcasecmp($mval, $label) == 0)) {
             $value[$k] = $name;
             $valueUpdated = TRUE;
             $isValid = TRUE;

--- a/CRM/Csvimport/Task/Import.php
+++ b/CRM/Csvimport/Task/Import.php
@@ -220,7 +220,7 @@ class CRM_Csvimport_Task_Import {
       $value = strtolower($value);
     }
     $value = explode('|', $value);
-    $value = array_filter($value); // filter empty values
+    $value = array_values(array_filter($value)); // filter empty values
     $valueUpdated = FALSE;
     $isValid = TRUE;
 

--- a/templates/CRM/Csvimport/Import/Form/DataSource.tpl
+++ b/templates/CRM/Csvimport/Import/Form/DataSource.tpl
@@ -41,6 +41,16 @@
         <td class="label">{$form.entity.label}</td>
         <td>{$form.entity.html}</td>
       </tr>
+      <tr class="crm-api-import-noteEntity-form-block-entity" id="noteEntityWrapper">
+        <td class="label">{$form.noteEntity.label}</td>
+        <td>{$form.noteEntity.html}<br/>
+          <span class="description">
+            {ts}Choose 'Set this in CSV' to use 'entity_table' field in next step. This allows you to import 'Notes' to multiple entities in same import.{/ts}
+            <br/>
+            {ts}Selecting an entity here will allow unique fields of this entity to be used in place of 'id'. Eg: External id for 'Contact'. (note: this will hide 'entity_table' field in next step){/ts}
+          </span>
+        </td>
+      </tr>
       <tr class="crm-api-import-uploadfile-form-block-uploadFile">
         <td class="label">{$form.uploadFile.label}</td>
         <td>{$form.uploadFile.html}<br/>
@@ -112,3 +122,20 @@
     <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
   </div>
 </div>
+{literal}
+  <script type="text/javascript" >
+    CRM.$('select#entity').on('change', function() {
+      if (CRM.$(this).val() == 'Note') {
+        CRM.$('#noteEntityWrapper').show();
+      } else {
+        CRM.$('#noteEntityWrapper').hide();
+      }
+    });
+    if (CRM.$('select#entity option:selected').val() == 'Note') {
+      CRM.$('#noteEntityWrapper').show();
+    }
+    else {
+      CRM.$('#noteEntityWrapper').hide();
+    }
+  </script>
+{/literal}

--- a/templates/CRM/Csvimport/Import/Form/DataSource.tpl
+++ b/templates/CRM/Csvimport/Import/Form/DataSource.tpl
@@ -85,6 +85,14 @@
           </span>
         </td>
       </tr>
+      <tr class="crm-import-datasource-form-block-ignoreCase">
+        <td class="label">{$form.ignoreCase.label}</td>
+        <td>{$form.ignoreCase.html} <br/>
+          <span class="description">
+            {ts}Ignore letter-case when mapping values to option fields (Eg. Individual Prefix). Note that this may produce unexpected results if you have multiple option names with same name like Ms. and ms.{/ts}
+          </span>
+        </td>
+      </tr>
       <tr class="crm-api-import-uploadfile-form-block-date_format">
         {include file="CRM/Core/Date.tpl"}
       </tr>


### PR DESCRIPTION
### Overview
This PR has the following updates
- Ignore letter case when mapping values against field option values. Eg: If 'Individual prefix' is like 'Mr.', 'mr.' will be treated the same. (Ofcourse this could cause unexpected results if there are multiple values for both 'Mr.' and 'mr.'. This info been added in description before enabling this option.)
- Fix issue when there are empty strings within multiple values (Bug fix)
- Support using unique fields (like external id for Contact) when importing 'Note' entity. Support using multiple entities to which 'Note' should be added.
- Limit value validation to options and boolean fields (code and performance improvement)

After this update the following PRs are not needed anymore (as we are only validating multiple options field and boolean fields) and have been removed(https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport/commit/d574896eb0a99a1cddc8d7854728239a2db90238).
https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport/pull/18
https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport/pull/16
https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport/pull/22