### PR TITLE
fix duplicate smarty assignment, initial fixes toward saved mapping widget

### DIFF
--- a/CRM/Csvimport/Import/Form/DataSource.php
+++ b/CRM/Csvimport/Import/Form/DataSource.php
@@ -169,6 +169,10 @@ class CRM_Csvimport_Import_Form_DataSource extends CRM_Import_Form_DataSource {
     );
     $this->assign('savedMapping', $mappingArray);
     $this->add('select', 'savedMapping', ts('Mapping Option'), ['' => ts('- select -')] + $mappingArray);
+
+    if ($loadedMapping = $this->get('loadedMapping')) {
+      $this->setDefaults(['savedMapping' => $loadedMapping]);
+    }
   }
 
   /**

--- a/CRM/Csvimport/Import/Form/MapField.php
+++ b/CRM/Csvimport/Import/Form/MapField.php
@@ -215,14 +215,14 @@ class CRM_Csvimport_Import_Form_MapField extends CRM_Import_Form_MapField {
   public function buildQuickForm() {
 
     //to save the current mappings
-    if (!$this->get('savedMapping')) {
+    if (!$this->getSubmittedValue('savedMapping')) {
       $saveDetailsName = ts('Save this field mapping');
       $this->applyFilter('saveMappingName', 'trim');
       $this->add('text', 'saveMappingName', ts('Name'));
       $this->add('text', 'saveMappingDesc', ts('Description'));
     }
     else {
-      $savedMapping = $this->get('savedMapping');
+      $savedMapping = $this->getSubmittedValue('savedMapping');
 
       list($mappingName) = CRM_Core_BAO_Mapping::getMappingFields($savedMapping);
 
@@ -277,16 +277,11 @@ class CRM_Csvimport_Import_Form_MapField extends CRM_Import_Form_MapField {
     for ($i = 0; $i < $this->_columnCount; $i++) {
       $sel = &$this->addElement('hierselect', "mapper[$i]", ts('Mapper for Field %1', [1 => $i]), NULL);
       $jsSet = FALSE;
-      if ($this->get('savedMapping')) {
+      if ($this->getSubmittedValue('savedMapping')) {
         if (isset($mappingName[$i])) {
-          if ($mappingName[$i] != ts('- do not import -')) {
-
-            $mappingHeader = array_keys($this->_mapperFields, $mappingName[$i]);
-
+          if ($mappingName[$i] != 'do_not_import') {
             $js .= "{$formName}['mapper[$i][3]'].style.display = 'none';\n";
-            $defaults["mapper[$i]"] = [
-              $mappingHeader[0]
-            ];
+            $defaults["mapper[$i]"] = [$mappingName[$i]];
             $jsSet = TRUE;
           }
           else {


### PR DESCRIPTION
A user reported that the "Load Saved Mapping" widget was missing.  That's because `buildQuickForm()` is calling `parent::buildQuickForm()` and the parent is now `CRM_Import_Form_DataSource` where much of this code already exists.

So I removed all the duplicate code - but also saw that `savedMapping` is constructed differently in this extension, so I moved that to run after `parent::buildQuickForm()`.

This all fixed the initial report.  the saved field mappings aren't loading on the next page though - it looks like they're not passed in the state machine.  I'm a little lost there at the moment, but I can see that `$page->get('entity')` returns a value but `$page->get('savedMapping')` returns `NULL`.