### PR TITLE
pass-by-ref function argument just changed in core master

### DIFF
--- a/CRM/Csvimport/Import/Form/MapField.php
+++ b/CRM/Csvimport/Import/Form/MapField.php
@@ -350,7 +350,7 @@ class CRM_Csvimport_Import_Form_MapField extends CRM_Import_Form_MapField {
    *
    * @return string
    */
-  public function defaultFromHeader($header, &$patterns) {
+  public function defaultFromHeader($header, $patterns) {
     return '';
   }
 


### PR DESCRIPTION
This just changed in core master a few days ago. Now gives `Declaration of CRM_Csvimport_Import_Form_MapField::defaultFromHeader($header, &$patterns) should be compatible with CRM_Import_Form_MapField::defaultFromHeader($header, $patterns)`