### PR TITLE
Mapping is lost when proceeding to next page after mapping

### DIFF
--- a/CRM/Csvimport/Import/Parser/Api.php
+++ b/CRM/Csvimport/Import/Parser/Api.php
@@ -389,17 +389,7 @@ class CRM_Csvimport_Import_Parser_Api extends CRM_Import_Parser {
   }
 
   /**
-   * the initializer code, called before the processing
-   *
-   * @throws \CiviCRM_API3_Exception
-   */
-  public function init(): void {
-    $this->setEntity($this->getSubmittedValue('entity'));
-    $this->setFieldMetadata();
-  }
-
-  /**
-   * Override parent to make assignee work.   
+   * Override parent to make assignee work.
    */
   protected function getOddlyMappedMetadataFields(): array {
     $fields = parent::getOddlyMappedMetadataFields();
@@ -407,5 +397,5 @@ class CRM_Csvimport_Import_Parser_Api extends CRM_Import_Parser {
     $fields['target_id'] = 'target_contact_id';
     return $fields;
   }
-  
+
 }


### PR DESCRIPTION
You get a warning about it via `Warning: foreach() argument must be of type array|object, null given in CRM_Import_Parser->getFieldMappings() (line 2070 of ...\CRM\Import\Parser.php).`

It gets saved to the userjob, but the parser still has a handle to the old userjob that didn't have a mapping yet. In the parent it [forces a reload of the userjob](https://github.com/civicrm/civicrm-core/blob/4ffd4cdf489abd021378487d2736e29f7680662f/CRM/Import/Parser.php#L1988) so let's call the parent, which also conveniently calls `setFieldMetadata()` so we don't need to do that too.
