### PR TITLE
Make assignee mapping work for activity import

### DIFF
--- a/CRM/Csvimport/Import/Parser/Api.php
+++ b/CRM/Csvimport/Import/Parser/Api.php
@@ -383,4 +383,14 @@ class CRM_Csvimport_Import_Parser_Api extends CRM_Import_Parser {
     $this->setFieldMetadata();
   }
 
+  /**
+   * Override parent to make assignee work.   
+   */
+  protected function getOddlyMappedMetadataFields(): array {
+    $fields = parent::getOddlyMappedMetadataFields();
+    $fields['assignee_id'] = 'assignee_contact_id';
+    $fields['target_id'] = 'target_contact_id';
+    return $fields;
+  }
+  
 }


### PR DESCRIPTION
It seems assignee_id now causes problems with "metadata" retrieval, because it's expecting assignee_contact_id and it leads to a crash during import with `TypeError: CRM_Import_Parser::getFieldMetadata(): Return value must be of type array, null returned in CRM_Import_Parser->getFieldMetadata() (line 1755 of ...\CRM\Import\Parser.php)`.

I don't know if this should be added directly to core's function, since assignee isn't available as a field in core's activity import.