### PR TITLE
Fix address import on PHP 8

### DIFF
--- a/CRM/Csvimport/Import/Parser/Api.php
+++ b/CRM/Csvimport/Import/Parser/Api.php
@@ -126,7 +126,12 @@ class CRM_Csvimport_Import_Parser_Api extends CRM_Import_Parser {
 
             if (count($fieldsInUniqueIndex) === 1) {
               $indexFieldName = $fieldsInUniqueIndex[0];
-
+              
+              // skip special case fields (such as the address.external_identifier)
+              if (empty($entityFieldMetadata[$indexFieldName])) {
+                continue;
+              }
+              
               $indexFieldMetadata = array_merge(
                 $entityFieldMetadata[$indexFieldName], [
                   'referenced_field' => $referenceField,


### PR DESCRIPTION
## Before

Unable to import addresses on PHP 8  sites, where it fails on the fields mapping page:

![1111111](https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport/assets/6275540/111dd99a-e2d9-42c2-9a1b-b797f68d916a)



## After

address import works fine 

![22222](https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport/assets/6275540/b9c45d32-fd54-4f78-9b0f-4d054c243af3)

![image](https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport/assets/6275540/0ce2f1c8-fef9-4c5b-9694-c941bd6f69f4)


## Technical notes

The address `external_identifier` is a special case field  and not part of the address entity, :
https://github.com/omarabuhussein/nz.co.fuzion.csvimport/blob/e5f0c93d02c81b29406527e88ebb996dd3abc8c3/CRM/Csvimport/Import/Parser/Api.php#L269

but the `getReferenceFields` method uses the API `getfields` action to get the Address entity fields meta data, then tries to to look for the `external_identifier` in there and then it tires to merge it with some other meta data (using array_merge) : https://github.com/omarabuhussein/nz.co.fuzion.csvimport/blob/e5f0c93d02c81b29406527e88ebb996dd3abc8c3/CRM/Csvimport/Import/Parser/Api.php#L135-L142

but because `external_identifier` is not available inside the response coming from `getfields` API call on the address entity (given it is not part of the Address entity), the first argument to the array_merge will be NULL, which on PHP 7 sites will just throw a warning, but on PHP 8 sites it fails with the following error:

```
array_merge(): Argument #1 must be of type array, null given in array_merge() (line 126 of /var/www/default/htdocs/httpdocs/profiles/devprofile/modules/contrib/civicrm/ext/nz.co.fuzion.csvimport/CRM/Csvimport/Import/Parser/Api.php)
```

