### PR TITLE
fix error with unknown base entity

### DIFF
--- a/CRM/Csvimport/Import/Parser/Api.php
+++ b/CRM/Csvimport/Import/Parser/Api.php
@@ -380,6 +380,13 @@ class CRM_Csvimport_Import_Parser_Api extends CRM_Import_Parser {
     return $this->getSubmittedValue('entity');
   }
 
+  public function getBaseEntity(): string {
+    if ($this->baseEntity === NULL) {
+      $this->baseEntity = $this->getSubmittedValue('entity');
+    }
+    return $this->baseEntity;
+  }
+
   /**
    * Set if entities can be updated using unique fields
    *


### PR DESCRIPTION
When you perform the first import with this extension on Civi >= 6.1, you get the following error:
```
TypeError: CRM_Import_Parser::getBaseEntity(): Return value must be of type string, null returned
```

This then occurs in just about any place where the SpecGatherer runs.  Partial backtrace below of this error on the SearchKit overview screen.

```
CRM_Import_Parser->getBaseEntity (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/CRM/Import/Parser.php:90)
Civi\Api4\Import\ImportSpecProvider->modifySpec (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/ext/civiimport/Civi/Api4/Import/ImportSpecProvider.php:94)
Civi\Api4\Service\Spec\SpecGatherer->getSpec (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/Civi/Api4/Service/Spec/SpecGatherer.php:143)
Civi\Api4\Service\Spec\SpecGatherer->getAllFields (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/Civi/Api4/Service/Spec/SpecGatherer.php:82)
Civi\Api4\Generic\DAOGetFieldsAction->getRecords (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/Civi/Api4/Generic/DAOGetFieldsAction.php:42)
Civi\Api4\Generic\BasicGetFieldsAction->_run (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/Civi/Api4/Generic/BasicGetFieldsAction.php:97)
Civi\Api4\Provider\ActionObjectProvider->invoke (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/Civi/Api4/Provider/ActionObjectProvider.php:91)
Civi\API\Kernel->runRequest (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/Civi/API/Kernel.php:153)
Civi\Api4\Generic\AbstractAction->execute (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/Civi/Api4/Generic/AbstractAction.php:251)
civicrm_api4 (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/api/api.php:102)
Civi\Search\Admin::getSchema (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/ext/search_kit/Civi/Search/Admin.php:152)
```