### PR TITLE
fixes #74: fix import to match civiimport passing associative arrays

### DIFF
--- a/CRM/Csvimport/Import/Parser/Api.php
+++ b/CRM/Csvimport/Import/Parser/Api.php
@@ -308,6 +308,8 @@ class CRM_Csvimport_Import_Parser_Api extends CRM_Import_Parser {
   public function import(array $values): void {
     $rowNumber = (int) ($values[array_key_last($values)]);
     $entity = $this->getSubmittedValue('entity');
+    // Civiimport wants a numeric array, not an associative array.
+    $values = array_values($values);
     try {
       $params = $this->getMappedRow($values);
       foreach ($params[$this->getEntity()] as $key => $value) {


### PR DESCRIPTION
With CiviImport, this extension stops working.

In `CRM_Csvimport_Import_Parser_Api::import()`, when it receives the row, it expects a numeric array, but Civiimport passes an associative array.  So when `getMappedRow()` is called, it assigns `null` to all the field to be imported.  Then you get a "missing mandatory fields" error like in #74.

This converts the array to a numeric array, and everything works after that.

@Guydn please confirm this works for you?