### PR TITLE
fix fatal error on 6.4

### DIFF
--- a/CRM/Csvimport/Import/Parser/Api.php
+++ b/CRM/Csvimport/Import/Parser/Api.php
@@ -22,7 +22,7 @@ class CRM_Csvimport_Import_Parser_Api extends CRM_Import_Parser {
 
   protected $_ignoreCase = FALSE;
 
-  protected $baseEntity = NULL;
+  protected $baseEntity = '';
 
   /**
    * Get user job information.


### PR DESCRIPTION
https://github.com/civicrm/civicrm-core/blob/master/CRM/Import/Parser.php#L89


TypeError: CRM_Import_Parser::getBaseEntity(): Return value must be of type string, null returned in CRM_Import_Parser->getBaseEntity() (line 90 of /var/sites/drupal10/vendor/civicrm/civicrm-core/CRM/Import/Parser.php).


https://chat.civicrm.org/civicrm/pl/c5n9nirghifkmmsdy7t9zbpisr
