### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Csvimport/Import/Parser/Api.php
+++ b/CRM/Csvimport/Import/Parser/Api.php
@@ -41,7 +41,7 @@ class CRM_Csvimport_Import_Parser_Api extends CRM_Import_Parser {
   }
 
   /**
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public function setFieldMetadata(): void {
     $this->importableFieldsMetadata = array_merge(
@@ -323,7 +323,7 @@ class CRM_Csvimport_Import_Parser_Api extends CRM_Import_Parser {
           try {
             $params['contact_id'] = (int) civicrm_api3($refEntity, 'getsingle', [$fieldMetadata['entity_field_name'] => $value])['id'];
           }
-          catch (CiviCRM_API3_Exception $e) {
+          catch (CRM_Core_Exception $e) {
             throw new CRM_Core_Exception('Failed to find referenced entity');
           }
         }


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.